### PR TITLE
Fix run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 This repo will generate all the files needed to compile/deploy Qt on Windows/OSX/Linux.
 
 ```bash
-./build.sh -platform linux-x64
-./build.sh -platform osx-x64
-./build.sh -platform win-x64
+./build.sh --platform linux-x64
+./build.sh --platform osx-x64
+./build.sh --platform win-x64
 ```
 
-The results are put into ````./output```.
+The results are put into `./output`.
 
 ```
 ./output/qt-5.12.2-ebc29a8-linux-x64-dev.tar.gz


### PR DESCRIPTION
They were previously incorrect -

```
✦ ❯ ./build.sh -platform linux-x64
Build.Program+Options
Sha: 04d1a8b
No platform exists for latform

qt-runtimes on  master [!] took 2s 
✦ ❯ ./build.sh --platform linux-x64
Build.Program+Options
Sha: 04d1a8b
Full version: qt-5.15.1-04d1a8b-linux-x64
Build: Starting... (default)
Build: clean: Starting...
Build: clean: Succeeded. (<1 ms)
Build: download: Starting...
```